### PR TITLE
Docker Machine is no longer installed by default

### DIFF
--- a/machine/install-machine.md
+++ b/machine/install-machine.md
@@ -5,12 +5,12 @@ title: Install Docker Machine
 hide_from_sitemap: true
 ---
 
-On macOS and Windows, Machine is installed along with other Docker products when
+On macOS and Windows, Machine is no longer installed along with other Docker products when
 you install the [Docker for Mac](/docker-for-mac/index.md),
 [Docker for Windows](/docker-for-windows/index.md), or
 [Docker Toolbox](/toolbox/overview.md).
 
-If you want only Docker Machine, you can install the Machine binaries directly
+If you want Docker Machine, you can install the Machine binaries directly
 by following the instructions in the next section. You can find the latest
 versions of the binaries on the [docker/machine release
 page](https://github.com/docker/machine/releases/){: target="_blank" class="_" }


### PR DESCRIPTION
Docker Machine is no longer installed by default along with other Docker products

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Update docker machine installation docs.
